### PR TITLE
Consolidate Dependabot into one grouped PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,25 @@
 # Dependabot configuration.
 # See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# NOTE: `package-ecosystem` was previously left as the empty placeholder `""`,
-# which is invalid — version updates never ran. Only Dependabot *security*
-# updates (which do not read this file) were opening PRs.
+# Tuned for minimum PR volume: everything for an ecosystem — majors, minors,
+# patches, prod and dev deps — lands in ONE catch-all group. Security
+# advisories land in a second, separate catch-all group (security-update
+# groups are independent of version-update groups by design). With
+# `open-pull-requests-limit: 1`, Dependabot updates that one open PR in
+# place as further compatible bumps become available, instead of opening a
+# new PR per package. This is the fewest PRs the tool supports — it can't be
+# reduced to a single PR *ever*, since a merged PR closes and the next
+# scheduled run (or the next disclosed advisory) opens a new one.
+#
+# Trade-off: bundling major versions in with routine patches means a single
+# PR can occasionally carry a breaking change alongside safe bumps, which is
+# harder to review or revert piecemeal than a standalone major-version PR.
+# If that's ever unwelcome, drop `major` from the ignored update-types list
+# below to split majors back out.
+#
+# The monthly schedule only throttles routine version-update checks — it
+# does NOT delay security advisories. Security-update groups trigger as soon
+# as GitHub discloses a vulnerability, independent of `schedule.interval`.
 
 version: 2
 updates:
@@ -11,29 +27,31 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      # Keep routine bumps to a couple of PRs a week rather than one per package.
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
+      npm-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   # Workflow actions — without this, pinned actions silently rot (this repo was
   # still on actions/checkout@v3 and hitting Node 20 runtime deprecation warnings).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      github-actions:
+      github-actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
Follow-up to #75, which had already merged by the time this was ready — branch was restarted from `main` and rebased. Fixes the "tons of Dependabot PRs" complaint.

## What changed

`.github/dependabot.yml` previously grouped only minor/patch bumps by dependency type (production vs. dev), so majors and any security-triggered PRs still arrived individually — that's most of the PR volume you were seeing.

Now, per ecosystem (`npm`, `github-actions`):
- **One catch-all group for version updates** — every dependency, every update type including majors, in a single `patterns: ["*"]` group.
- **One separate catch-all group for security advisories** — security-update groups are independent of version-update groups by GitHub's design, so this is a second (much rarer) PR, not folded into the first.
- **`open-pull-requests-limit: 1`** — Dependabot amends the one open version-update PR in place as further compatible bumps land, instead of opening a new PR per package.
- **Schedule moved to `monthly`** — throttles routine version-update checks. This does **not** delay security advisories, which fire independently of `schedule.interval` the moment GitHub discloses a vulnerability.

## What this gets you, and what it can't

At steady state: at most one open "routine updates" PR and, occasionally, one open "security" PR — each absorbing new compatible bumps rather than spawning siblings. Not literally "one PR ever" (impossible — a merged PR closes, and the next scheduled run or next disclosed advisory opens a fresh one), but the closest the tool supports.

**Trade-off worth knowing:** bundling major versions into the same PR as routine patches means an occasional PR could carry a breaking major bump alongside safe bumps, which is harder to review or revert piecemeal than a standalone major-version PR. If that becomes a problem, splitting majors back out is a one-line change (add `update-types: ["minor", "patch"]` under the `npm-all` / `github-actions-all` groups).

## Testing

- YAML parses cleanly (`yaml.safe_load`)
- Verified against Dependabot's documented group semantics: `applies-to: security-updates` groups are separate from the default `version-updates` groups; `open-pull-requests-limit` only caps version-update PRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M14CBb8KBM85sGPKcM2b3z)_