### PR TITLE
Redesign Prepare tab + live Controlled Burn requirements card

### DIFF
--- a/public/Content/bfdpDates.json
+++ b/public/Content/bfdpDates.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Bungendore sits in the NSW RFS 'Southern Ranges' district. The Bush Fire Danger Period (BFDP) start/end dates below are the statewide statutory default (1 Oct - 31 Mar). The RFS Commissioner can vary these per district in a given year (earlier start, later end, etc). When that happens, check the authoritative table at https://www.rfs.nsw.gov.au/fire-information/BFDP and update 'start'/'end' below by hand - no code change needed. This file is read by isBushfireDangerPeriod() in main.js, which falls back to the same statutory default if this file is missing or fails to load.",
+  "start": "2026-10-01",
+  "end": "2027-03-31"
+}

--- a/public/Content/prepareContent.md
+++ b/public/Content/prepareContent.md
@@ -1,18 +1,10 @@
 ### Bushfire Ready: Your 4-Step Action Plan
 
-**Be Prepared. Stay Safe.** A well-prepared home and a solid plan give you the best chance against a bushfire.
+**Be prepared. Stay safe.** A well-prepared home and a solid plan give you the best chance against a bushfire.
 
-> **1. TALK IT OUT: Plan Your Response**
-> What will your household do if a bushfire threatens? Have the conversation now. Dinner time is a great time – everyone's there and focused.
+1. **Talk It Out: Plan Your Response** What will your household do if a bushfire threatens? Have the conversation now — dinner time is a great time, when everyone's there and focused.
+2. **Home Prep: Reduce Your Risk** Simple actions make a big difference. Keep grass short, clear debris, and ensure easy access around your home.
+3. **Know the Alerts: Understand the Danger** Fire danger ratings and alert levels change. Check the NSW RFS website and the Hazards Near Me NSW app regularly, and know what each alert means for you.
+4. **Stay Informed: Your Lifeline** During a fire, information is critical. Keep emergency numbers and official apps handy, and monitor conditions constantly.
 
-> **2. HOME PREP: Reduce Your Risk**
-> Simple actions make a big difference. Keep grass short, clear debris, and ensure easy access around your home. Get your property bushfire ready!
-
-> **3. KNOW THE ALERTS: Understand the Danger**
-> Fire danger ratings and alert levels change. Check the NSW RFS website and the 'Fires Near Me' app regularly. Know what each alert means for you.
-
-> **4. STAY INFORMED: Your Lifeline**
-> During a fire, information is critical. Keep emergency numbers, official websites, and apps handy. Monitor conditions constantly.
-
-**Don't wait!** A prepared home and a clear plan are your best defense.
-[**Download Your Complete Bush Fire Survival Plan PDF**](https://www.rfs.nsw.gov.au/__data/assets/pdf_file/0003/36597/BFSP-Complete.pdf)
+**Don't wait!** A prepared home and a clear plan are your best defence.

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -415,11 +415,24 @@ h3 {
   margin-top: 0;
 }
 
+/* Fixed crop ratio + object-fit so source photos of any orientation fill a
+   consistent, compact banner instead of stretching the column to their
+   full natural height (was ~1:1 for portrait-ish source photos). Ratio
+   widens on tablet+ where there's more horizontal room to work with. */
 .tab-layout__image {
+  display: block;
   width: 100%;
   height: auto;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
   border-radius: 10px;
   margin-bottom: var(--space-lg);
+}
+
+@media (min-width: 769px) {
+  .tab-layout__image {
+    aspect-ratio: 2.6 / 1;
+  }
 }
 
 .tab-layout__figure {
@@ -430,6 +443,62 @@ h3 {
   font-size: 0.8rem;
   color: var(--clear-text-secondary);
   margin-top: var(--space-xs);
+}
+
+/* "Prepare" tab action-plan steps — numbered red circle badges at the same
+   compact scale as the rest of the Clear Skies page (.quick-links,
+   .strip-cell), replacing the browser's default blockquote/list styling.
+   Scoped to #prepareContent since that's the only markdown-rendered block
+   using this ol/li pattern. */
+#prepareContent h3 {
+  font-size: var(--font-size-h3);
+  font-weight: 800;
+  color: var(--clear-body-text);
+  margin: var(--space-lg) 0 var(--space-sm);
+}
+
+#prepareContent ol {
+  list-style: none;
+  counter-reset: step;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  margin: 0 0 var(--space-lg);
+  padding: 0;
+}
+
+/* Badge is an absolutely-positioned ::before rather than a flex sibling —
+   a block-level heading followed by plain text inside a flex item gets
+   blockified into two separate side-by-side flex items instead of
+   stacking, so plain block flow (with padding to clear the badge) is used
+   here instead. */
+#prepareContent ol li {
+  counter-increment: step;
+  position: relative;
+  padding-left: 40px;
+  min-height: 28px;
+}
+
+#prepareContent ol li::before {
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: var(--rfs-core-red);
+  color: var(--text-color-light);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 28px;
+  text-align: center;
+}
+
+#prepareContent ol li strong:first-child {
+  display: block;
+  color: var(--clear-body-text);
+  margin-bottom: 2px;
 }
 
 .quick-links {
@@ -929,6 +998,22 @@ a:focus {
   font-weight: 700;
 }
 
+/* Cell 4's own CTA link (see .strip-cell--burn below) — same treatment as
+   the map cell's link but its own class since the two cells vary
+   independently. */
+.strip-cell__cta {
+  color: var(--rfs-core-red);
+  text-decoration: none;
+  font-size: 12.5px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.strip-cell__cta:hover,
+.strip-cell__cta:focus {
+  text-decoration: underline;
+}
+
 /* ── Fire Danger strip cell colour bands (Cell 1) ────────────────────────────
  *
  * Lower-risk levels (No Rating, Moderate, High): a coloured top strip on the
@@ -1000,16 +1085,50 @@ a:focus {
   color: var(--rfs-white);
 }
 
-/* Warning Level / Total Fire Ban cells: neutral calm-state tint. Cell 2
-   (Incidents) intentionally stays untinted per the design spec. */
+/* Warning Level / Controlled Burn cells: neutral calm-state tint by default.
+   Cell 2 (Incidents) intentionally stays untinted per the design spec. */
 .strip-cell--warning,
-.strip-cell--toban {
+.strip-cell--burn {
   background-color: var(--clear-neutral-cell-bg);
 }
 
 #stripWarningLevel,
-#stripTotalFireBan {
+#stripBurnStatus {
   color: var(--clear-neutral-cell-fg);
+}
+
+/* Cell 4 (Controlled Burn) escalation — same colour language as the Fire
+   Danger cell: amber once fire danger reaches High (permits may be
+   suspended), full alert red when a Total Fire Ban is actually in effect
+   (no burning permitted at all, notification is moot). Driven by
+   updateControlledBurnCell() in main.js from the same district feed
+   already used for the Fire Danger cell. */
+.strip-cell--burn:has(#stripBurnStatus[data-state="high"]) {
+  background-color: var(--clear-incident-bg);
+}
+.strip-cell--burn:has(#stripBurnStatus[data-state="high"]) #stripBurnStatus,
+.strip-cell--burn:has(#stripBurnStatus[data-state="high"]) #stripBurnSub {
+  color: var(--clear-incident-fg);
+}
+.strip-cell--burn:has(#stripBurnStatus[data-state="high"]) .strip-cell__cta {
+  color: var(--clear-incident-fg);
+  text-decoration: underline;
+}
+
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]) {
+  background-color: var(--rfs-core-red);
+}
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]):hover {
+  background-color: #c42216;
+}
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]) .strip-cell__label,
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]) #stripBurnStatus,
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]) #stripBurnSub {
+  color: var(--rfs-white);
+}
+.strip-cell--burn:has(#stripBurnStatus[data-state="toban"]) .strip-cell__cta {
+  color: var(--rfs-white);
+  text-decoration: underline;
 }
 
 /* Incident-active state: strip cell 5 shows context message */

--- a/public/index.html
+++ b/public/index.html
@@ -26,8 +26,22 @@
 
     <!-- Preload the hero image to improve LCP -->
     <!-- Desktop: WebP preferred, JPEG fallback; mobile gets its own asset via CSS -->
-    <link rel="preload" as="image" href="/Images/hero4-desktop.webp" type="image/webp" fetchpriority="high" media="(min-width: 769px)" />
-    <link rel="preload" as="image" href="/Images/hero4-mobile.webp" type="image/webp" fetchpriority="high" media="(max-width: 768px)" />
+    <link
+      rel="preload"
+      as="image"
+      href="/Images/hero4-desktop.webp"
+      type="image/webp"
+      fetchpriority="high"
+      media="(min-width: 769px)"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="/Images/hero4-mobile.webp"
+      type="image/webp"
+      fetchpriority="high"
+      media="(max-width: 768px)"
+    />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -60,7 +74,10 @@
         class="utility-link"
         ><i class="fas fa-hand-holding-heart" aria-hidden="true"></i>Donate</a
       >
-      <button id="contactUsBtn" class="contact-trigger utility-link utility-link--btn utility-link--emphasis">
+      <button
+        id="contactUsBtn"
+        class="contact-trigger utility-link utility-link--btn utility-link--emphasis"
+      >
         <i class="fas fa-envelope" aria-hidden="true"></i>Contact
       </button>
       <span class="utility-bar__social">
@@ -125,39 +142,91 @@
       </div>
 
       <!-- Live Status Strip (Phase 3): replaces header status bar, dashboard overlay, mobile panel, and fire-info summary card -->
-      <section id="liveStatusStrip" class="live-status-strip" aria-label="Current fire status for our area">
+      <section
+        id="liveStatusStrip"
+        class="live-status-strip"
+        aria-label="Current fire status for our area"
+      >
         <!-- Cell 1: Fire Danger Rating -->
-        <article class="strip-cell strip-cell--danger" role="group" aria-label="Fire Danger Rating" tabindex="0">
-          <p class="strip-cell__label"><i class="fas fa-thermometer-half" aria-hidden="true"></i> Fire Danger</p>
+        <article
+          class="strip-cell strip-cell--danger"
+          role="group"
+          aria-label="Fire Danger Rating"
+          tabindex="0"
+        >
+          <p class="strip-cell__label">
+            <i class="fas fa-thermometer-half" aria-hidden="true"></i> Fire Danger
+          </p>
           <div id="fireDangerRatingCell" class="strip-cell__value tabular-nums">Loading…</div>
           <p id="fireDangerMessage" class="strip-cell__sub">Fetching latest data…</p>
         </article>
 
         <!-- Cell 2: Active Incidents -->
-        <article class="strip-cell strip-cell--incidents" role="group" aria-label="Active Incidents" tabindex="0">
-          <p class="strip-cell__label"><i class="fas fa-fire-alt" aria-hidden="true"></i> Incidents</p>
+        <article
+          class="strip-cell strip-cell--incidents"
+          role="group"
+          aria-label="Active Incidents"
+          tabindex="0"
+        >
+          <p class="strip-cell__label">
+            <i class="fas fa-fire-alt" aria-hidden="true"></i> Incidents
+          </p>
           <div class="strip-cell__value tabular-nums"><span id="incidentTotalCount">0</span></div>
           <div id="incidentCountCell" class="strip-cell__breakdown"></div>
           <p id="incidentCountLabel" class="strip-cell__sub">No active incidents in our area</p>
         </article>
 
         <!-- Cell 3: Warning Level -->
-        <article class="strip-cell strip-cell--warning" role="group" aria-label="Current Warning Level" tabindex="0">
-          <p class="strip-cell__label"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Warning Level</p>
+        <article
+          class="strip-cell strip-cell--warning"
+          role="group"
+          aria-label="Current Warning Level"
+          tabindex="0"
+        >
+          <p class="strip-cell__label">
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Warning Level
+          </p>
           <div id="stripWarningLevel" class="strip-cell__value">None</div>
           <p class="strip-cell__sub">No current warning</p>
         </article>
 
-        <!-- Cell 4: Total Fire Ban -->
-        <article class="strip-cell strip-cell--toban" role="group" aria-label="Total Fire Ban" tabindex="0">
-          <p class="strip-cell__label"><i class="fas fa-ban" aria-hidden="true"></i> Total Fire Ban</p>
-          <div id="stripTotalFireBan" class="strip-cell__value">No</div>
-          <p class="strip-cell__sub">No total fire ban today</p>
+        <!-- Cell 4: Controlled Burn requirements — dynamic: escalates from
+             "notify/permit" guidance to a High-danger caution to a full
+             Total Fire Ban alert, driven by the same district feed as the
+             Fire Danger cell (see updateControlledBurnCell in main.js). -->
+        <article
+          class="strip-cell strip-cell--burn"
+          role="group"
+          aria-label="Controlled burn requirements"
+          tabindex="0"
+        >
+          <p class="strip-cell__label">
+            <i class="fas fa-fire" aria-hidden="true"></i> Controlled Burn
+          </p>
+          <div id="stripBurnStatus" class="strip-cell__value tabular-nums">Loading&hellip;</div>
+          <p id="stripBurnSub" class="strip-cell__sub">
+            Checking today&rsquo;s requirements&hellip;
+          </p>
+          <a
+            id="stripBurnLink"
+            href="https://www.rfs.nsw.gov.au/notify"
+            target="_blank"
+            rel="noopener"
+            class="strip-cell__cta"
+            >Notify RFS &rarr;</a
+          >
         </article>
 
         <!-- Cell 5: Map context / full-map CTA -->
-        <article class="strip-cell strip-cell--map" role="group" aria-label="Incident Map" tabindex="0">
-          <p class="strip-cell__label"><i class="fas fa-map-marked-alt" aria-hidden="true"></i> Incident Map</p>
+        <article
+          class="strip-cell strip-cell--map"
+          role="group"
+          aria-label="Incident Map"
+          tabindex="0"
+        >
+          <p class="strip-cell__label">
+            <i class="fas fa-map-marked-alt" aria-hidden="true"></i> Incident Map
+          </p>
           <a href="#info" class="strip-map-cta-btn">View Full Map &rarr;</a>
           <p class="strip-cell__sub">Open fire incident map</p>
         </article>
@@ -243,20 +312,36 @@
                       <!-- Incident map (moved from summary card in Phase 3) -->
                       <div class="fire-info-map" id="fireInfoMapContainer">
                         <div class="map-toolbar">
-                          <button id="mapExpandBtn" class="map-expand-btn" type="button" aria-expanded="false">
+                          <button
+                            id="mapExpandBtn"
+                            class="map-expand-btn"
+                            type="button"
+                            aria-expanded="false"
+                          >
                             <i class="fas fa-expand"></i>
                             <span>Expand</span>
                           </button>
                         </div>
                         <div class="map-layout">
                           <div id="map" aria-label="Local incident map"></div>
-                          <aside id="mapDetailPanel" class="map-detail-panel" aria-live="polite" hidden></aside>
+                          <aside
+                            id="mapDetailPanel"
+                            class="map-detail-panel"
+                            aria-live="polite"
+                            hidden
+                          ></aside>
                         </div>
                       </div>
                       <ul class="map-legend">
-                        <li><img src="/Images/advice.png" alt="" class="map-legend__icon" />Advice</li>
                         <li>
-                          <img src="/Images/watch-and-act.png" alt="" class="map-legend__icon" />Watch &amp; Act
+                          <img src="/Images/advice.png" alt="" class="map-legend__icon" />Advice
+                        </li>
+                        <li>
+                          <img
+                            src="/Images/watch-and-act.png"
+                            alt=""
+                            class="map-legend__icon"
+                          />Watch &amp; Act
                         </li>
                         <li>
                           <img
@@ -265,24 +350,40 @@
                             class="map-legend__icon"
                           />Emergency Warning
                         </li>
-                        <li><span class="map-legend__dot map-legend__dot--station"></span>Station</li>
+                        <li>
+                          <span class="map-legend__dot map-legend__dot--station"></span>Station
+                        </li>
                       </ul>
                       <a href="#info" class="map-legend-link">View full incident map &rarr;</a>
                       <div id="fireInfoTableContainer" class="grid-container"></div>
                     </div>
                     <aside class="quick-links">
                       <p class="quick-links__kicker">Quick Links</p>
-                      <a href="https://www.rfs.nsw.gov.au" target="_blank" rel="noopener" class="quick-links__row"
+                      <a
+                        href="https://www.rfs.nsw.gov.au"
+                        target="_blank"
+                        rel="noopener"
+                        class="quick-links__row"
                         ><i class="fas fa-globe" aria-hidden="true"></i>NSW RFS Website</a
                       >
-                      <a href="https://www.rfs.nsw.gov.au" target="_blank" rel="noopener" class="quick-links__row"
-                        ><i class="fas fa-mobile-alt" aria-hidden="true"></i>Fires Near Me App</a
+                      <a
+                        href="https://www.nsw.gov.au/emergency/hazards-near-me-app"
+                        target="_blank"
+                        rel="noopener"
+                        class="quick-links__row"
+                        ><i class="fas fa-mobile-alt" aria-hidden="true"></i>Hazards Near Me NSW
+                        App</a
                       >
-                      <a href="https://www.rfs.nsw.gov.au" target="_blank" rel="noopener" class="quick-links__row"
+                      <a
+                        href="https://www.rfs.nsw.gov.au/fire-information/BFDP"
+                        target="_blank"
+                        rel="noopener"
+                        class="quick-links__row"
                         ><i class="fas fa-ban" aria-hidden="true"></i>Total Fire Ban Info</a
                       >
                       <div class="quick-links__row quick-links__row--emphasis">
-                        <i class="fas fa-phone" aria-hidden="true"></i>Emergency &mdash; always call 000
+                        <i class="fas fa-phone" aria-hidden="true"></i>Emergency &mdash; always call
+                        000
                       </div>
                     </aside>
                   </div>
@@ -302,9 +403,12 @@
                   <h2>Prepare for Bushfires</h2>
                   <div class="tab-layout">
                     <div class="tab-layout__main">
-                      <img src="/Images/prepare.jpeg" alt="Prepare for Bushfires" class="tab-layout__image" />
+                      <img
+                        src="/Images/prepare.jpeg"
+                        alt="Prepare for Bushfires"
+                        class="tab-layout__image"
+                      />
                       <div id="prepareContent"></div>
-                      <div id="BFDPContent"></div>
                     </div>
                     <aside class="quick-links">
                       <p class="quick-links__kicker">Quick Links</p>
@@ -321,15 +425,16 @@
                         target="_blank"
                         rel="noopener"
                         class="quick-links__row"
-                        ><i class="fas fa-file-pdf" aria-hidden="true"></i>Download Survival Plan PDF</a
+                        ><i class="fas fa-file-pdf" aria-hidden="true"></i>Download Survival Plan
+                        PDF</a
                       >
                       <a
-                        href="https://nswrfsprod.service-now.com/guardian_csp?id=guardian_index"
+                        href="https://www.rfs.nsw.gov.au/notify"
                         target="_blank"
                         rel="noopener"
                         class="quick-links__row"
-                        ><i class="fas fa-file-signature" aria-hidden="true"></i>Apply for a Fire Permit
-                        / Report a Burn</a
+                        ><i class="fas fa-file-signature" aria-hidden="true"></i>Notify a Burn /
+                        Apply for a Fire Permit</a
                       >
                     </aside>
                   </div>
@@ -338,7 +443,12 @@
             </div>
 
             <!-- Membership Tab -->
-            <div class="tab-panel" role="tabpanel" id="membership-tab" aria-labelledby="tab-membership">
+            <div
+              class="tab-panel"
+              role="tabpanel"
+              id="membership-tab"
+              aria-labelledby="tab-membership"
+            >
               <div class="accordion-header mobile-only" data-accordion="membership">
                 <i class="fas fa-users"></i>
                 <span>Membership</span>
@@ -362,8 +472,8 @@
                         target="_blank"
                         rel="noopener"
                         class="quick-links__row"
-                        ><i class="fas fa-user-plus" aria-hidden="true"></i>Explore Roles &amp; Apply for
-                        Membership</a
+                        ><i class="fas fa-user-plus" aria-hidden="true"></i>Explore Roles &amp;
+                        Apply for Membership</a
                       >
                       <a
                         href="https://www.rfs.nsw.gov.au"
@@ -374,7 +484,8 @@
                         Volunteering</a
                       >
                       <div class="quick-links__row">
-                        <i class="fas fa-clock" aria-hidden="true"></i>Visit us Friday nights from 7pm
+                        <i class="fas fa-clock" aria-hidden="true"></i>Visit us Friday nights from
+                        7pm
                       </div>
                     </aside>
                   </div>
@@ -401,7 +512,9 @@
                           alt="The brigade at the donation of the Black Summer Bungendore Fridge"
                           class="tab-layout__image"
                         />
-                        <figcaption>The brigade at the donation of the Black Summer Bungendore Fridge</figcaption>
+                        <figcaption>
+                          The brigade at the donation of the Black Summer Bungendore Fridge
+                        </figcaption>
                       </figure>
                       <div id="communityEventsSection">
                         <h4>Community Events</h4>
@@ -410,7 +523,11 @@
                     </div>
                     <aside class="quick-links">
                       <p class="quick-links__kicker">Quick Links</p>
-                      <button type="button" id="eventsContactBtn" class="contact-trigger quick-links__row quick-links__row--btn">
+                      <button
+                        type="button"
+                        id="eventsContactBtn"
+                        class="contact-trigger quick-links__row quick-links__row--btn"
+                      >
                         <i class="fas fa-envelope" aria-hidden="true"></i>Contact Us
                       </button>
                       <a
@@ -425,7 +542,8 @@
                         target="_blank"
                         rel="noopener"
                         class="quick-links__row"
-                        ><i class="fab fa-instagram" aria-hidden="true"></i>Follow us on Instagram</a
+                        ><i class="fab fa-instagram" aria-hidden="true"></i>Follow us on
+                        Instagram</a
                       >
                     </aside>
                   </div>

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -104,19 +104,25 @@ document.addEventListener("DOMContentLoaded", () => {
     toggleNavLogo(); // Initial check
   }
 
-  // Helper function for bushfire danger period check.
+  // Bush Fire Danger Period (BFDP) check.
   //
-  // This is the statewide statutory default (1 Oct – 31 Mar) only. The NSW
-  // RFS Commissioner can vary the actual start/end date per district, and
+  // The RFS Commissioner can vary the BFDP start/end date per district, and
   // publishes the authoritative, currently-in-force dates as a live table
-  // at https://www.rfs.nsw.gov.au/fire-information/BFDP — this calendar
-  // check is a best-effort fallback for the strip cell's live/loading
-  // state, not a substitute for that page. It's why every Controlled Burn
-  // cell state links out to an official RFS tool (Guardian notify/permit
-  // portal or the BFDP page itself) rather than asserting a requirement
-  // outright: the RFS tools make the authoritative, address-specific call.
+  // at https://www.rfs.nsw.gov.au/fire-information/BFDP. That page has no
+  // public data feed, so instead of guessing or scraping it, the actual
+  // dates for our district live in Content/bfdpDates.json — a small file a
+  // brigade member updates by hand (checking that RFS page) whenever the
+  // Commissioner varies them. bfdpPeriod is populated from it below; if the
+  // file is missing or hasn't loaded yet, this falls back to the statewide
+  // statutory default (1 Oct – 31 Mar) so the strip cell still shows a
+  // reasonable state immediately on page load.
+  let bfdpPeriod = null; // { start: Date, end: Date }, set once bfdpDates.json loads (see below)
+
   function isBushfireDangerPeriod() {
     const now = new Date();
+    if (bfdpPeriod) {
+      return now >= bfdpPeriod.start && now <= bfdpPeriod.end;
+    }
     const month = now.getMonth() + 1; // getMonth() is zero-based
     return month >= 10 || month <= 3;
   }
@@ -189,9 +195,16 @@ document.addEventListener("DOMContentLoaded", () => {
 
   if (fireDangerRatingCell && fireDangerMessage) {
     // Check if necessary strip elements exist
-    fetch("/Content/AFDRSMessages.json")
-      .then((response) => response.json())
-      .then((fireDangerRatings) => {
+    Promise.all([
+      fetch("/Content/AFDRSMessages.json").then((response) => response.json()),
+      fetch("/Content/bfdpDates.json")
+        .then((response) => response.json())
+        .catch(() => null), // isBushfireDangerPeriod() falls back to the statutory default
+    ])
+      .then(([fireDangerRatings, bfdpDates]) => {
+        if (bfdpDates) {
+          bfdpPeriod = { start: new Date(bfdpDates.start), end: new Date(bfdpDates.end) };
+        }
         fetch(`${getApiBaseUrl()}/api/fire-danger`)
           .then((response) => {
             if (!response.ok) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -104,44 +104,82 @@ document.addEventListener("DOMContentLoaded", () => {
     toggleNavLogo(); // Initial check
   }
 
-  // Helper function for bushfire danger period check
+  // Helper function for bushfire danger period check.
+  //
+  // This is the statewide statutory default (1 Oct – 31 Mar) only. The NSW
+  // RFS Commissioner can vary the actual start/end date per district, and
+  // publishes the authoritative, currently-in-force dates as a live table
+  // at https://www.rfs.nsw.gov.au/fire-information/BFDP — this calendar
+  // check is a best-effort fallback for the strip cell's live/loading
+  // state, not a substitute for that page. It's why every Controlled Burn
+  // cell state links out to an official RFS tool (Guardian notify/permit
+  // portal or the BFDP page itself) rather than asserting a requirement
+  // outright: the RFS tools make the authoritative, address-specific call.
   function isBushfireDangerPeriod() {
     const now = new Date();
     const month = now.getMonth() + 1; // getMonth() is zero-based
     return month >= 10 || month <= 3;
   }
 
-  // Bushfire Danger Period Content
-  const BFDPContent = document.getElementById("BFDPContent");
-  if (BFDPContent) {
-    // Check if element exists
-    const inDangerPeriod = isBushfireDangerPeriod();
-    const statusText = inDangerPeriod
-      ? "We are currently in the bushfire danger period. If you would like to light a fire any larger than a cooking fire you must;"
-      : "We are not currently in the bushfire danger period. If you would like to light a fire any larger than a cooking fire you must;";
+  // Cell 4 (Controlled Burn) — combines the live district feed (Total Fire
+  // Ban + fire danger rating, read from the same XML already fetched below
+  // for Cell 1) with the Bush Fire Danger Period calendar, so the strip
+  // shows the one requirement that actually applies today.
+  //
+  // The Bush Fire Danger Period (BFDP) and the daily Fire Danger Rating
+  // (FDR) are two separate things and must not be conflated: the BFDP is a
+  // fixed statutory season (default 1 Oct – 31 Mar) that alone determines
+  // whether a fire permit is required at all; the FDR is a day-to-day
+  // condition rating that determines Total Fire Bans and, only *within* an
+  // active BFDP, whether an existing permit gets suspended for the day. A
+  // High+ rating on a day outside the BFDP has no bearing on permits,
+  // because no permit is required or in force to suspend.
+  // Escalates: Total Fire Ban (no burning at all, any time of year) >
+  // BFDP + High+ rating (permit may be suspended) > BFDP alone (permit
+  // required) > outside BFDP (notify-only, year-round baseline).
+  function updateControlledBurnCell(fireBanToday, dangerLevelToday) {
+    const statusEl = document.getElementById("stripBurnStatus");
+    const subEl = document.getElementById("stripBurnSub");
+    const linkEl = document.getElementById("stripBurnLink");
+    if (!statusEl || !subEl) return;
 
-    const tableHTML = `
-    <p>${statusText}</p>
-    <table>
-      <tr>
-        <td>Not light your fire on days of total fire ban or high fire danger</td>
-        <td><input type="checkbox" checked disabled></td>
-      </tr>
-      <tr>
-        <td>Notify your neighbours</td>
-        <td><input type="checkbox" checked disabled></td>
-      </tr>
-      <tr>
-        <td>Notify the RFS of your burn</td>
-        <td><input type="checkbox" checked disabled></td>
-      </tr>
-      <tr>
-        <td>Have been issued a fire permit</td>
-        <td><input type="checkbox" ${inDangerPeriod ? "checked" : ""} disabled></td>
-      </tr>
-    </table>
-  `;
-    BFDPContent.innerHTML = DOMPurify.sanitize(tableHTML);
+    if (fireBanToday === "Yes") {
+      statusEl.textContent = "No Burning";
+      statusEl.setAttribute("data-state", "toban");
+      subEl.textContent =
+        "Total Fire Ban in effect — all permits and exemptions are suspended today.";
+      if (linkEl) {
+        linkEl.textContent = "Total Fire Ban info →";
+        linkEl.href = "https://www.rfs.nsw.gov.au/fire-information/BFDP";
+      }
+      return;
+    }
+
+    if (linkEl) {
+      linkEl.textContent = "Notify RFS →";
+      linkEl.href = "https://www.rfs.nsw.gov.au/notify";
+    }
+
+    const inDangerPeriod = isBushfireDangerPeriod();
+    const highDangerLevels = ["HIGH", "EXTREME", "CATASTROPHIC"];
+    const isHighDanger = Boolean(dangerLevelToday) && highDangerLevels.includes(dangerLevelToday);
+
+    if (inDangerPeriod && isHighDanger) {
+      statusEl.textContent = "Check Permit";
+      statusEl.setAttribute("data-state", "high");
+      subEl.textContent =
+        "Bush Fire Danger Period, and fire danger is High or above today — your permit may be suspended. Check before you light up.";
+    } else if (inDangerPeriod) {
+      statusEl.textContent = "Permit Required";
+      statusEl.setAttribute("data-state", "bfdp");
+      subEl.textContent =
+        "Bush Fire Danger Period: get a permit, and notify the RFS & your neighbours 24 hrs ahead.";
+    } else {
+      statusEl.textContent = "Notify First";
+      statusEl.setAttribute("data-state", "normal");
+      subEl.textContent =
+        "No permit needed, but notify the RFS & your neighbours at least 24 hrs ahead.";
+    }
   }
 
   // Fire Danger Rating and Incidents
@@ -179,6 +217,10 @@ document.addEventListener("DOMContentLoaded", () => {
                 .replace(/\s+/g, " ")
                 .trim()
                 .toUpperCase();
+
+              const fireBanNode = southernRangesDistrict.getElementsByTagName("FireBanToday")[0];
+              const fireBanToday = fireBanNode ? fireBanNode.textContent.trim() : "";
+              updateControlledBurnCell(fireBanToday, dangerLevelToday);
 
               const ratingInfo = fireDangerRatings.FireDangerRatings.find(
                 (rating) =>
@@ -227,6 +269,7 @@ document.addEventListener("DOMContentLoaded", () => {
               fireDangerRatingCell.textContent = "No Rating";
               fireDangerRatingCell.setAttribute("data-level", "NO RATING");
               fireDangerMessage.textContent = "Rating information currently unavailable.";
+              updateControlledBurnCell("", "");
             }
           })
           .catch((error) => {
@@ -236,6 +279,7 @@ document.addEventListener("DOMContentLoaded", () => {
               fireDangerRatingCell.setAttribute("data-level", "NO RATING");
             }
             if (fireDangerMessage) fireDangerMessage.textContent = "Could not load rating message.";
+            updateControlledBurnCell("", "");
 
             if (typeof window.updateEmergencyDashboard === "function") {
               window.updateEmergencyDashboard({
@@ -250,6 +294,7 @@ document.addEventListener("DOMContentLoaded", () => {
         console.error("Error fetching the JSON data:", error);
         if (fireDangerRatingCell) fireDangerRatingCell.textContent = "Error";
         if (fireDangerMessage) fireDangerMessage.textContent = "Could not load rating message.";
+        updateControlledBurnCell("", "");
       });
   }
 });


### PR DESCRIPTION
## Summary

Started as a layout/copy refinement of the Prepare tab (per a reference screenshot) and grew, based on feedback during review, into fixing a real gap: the site's Total Fire Ban cell was static/unwired, and burning requirements were buried in a non-interactive checklist most people would never scroll to.

**Prepare tab (visual/copy):**
- Tab images (`prepare.jpeg`, `communityEvent.jpeg`) were rendering at their full natural aspect ratio — one was nearly square and dominated the page. Now cropped to a compact banner (`aspect-ratio` + `object-fit: cover`), narrower on mobile, wider on tablet+.
- The 4-step action plan was unstyled markdown blockquotes with no visual hierarchy. Restyled as numbered red-circle steps at the same compact scale as the rest of the "Clear Skies" design (`.quick-links`, `.strip-cell`).
- Removed a duplicate "Download Survival Plan" CTA from the body copy (already present in Quick Links).
- "Fires Near Me" → "Hazards Near Me NSW" (renamed by RFS in 2023). Permit/notification links now point at the current official one-stop tool, `rfs.nsw.gov.au/notify`.

**Controlled Burn card (new):**
- The Live Status Strip's "Total Fire Ban" cell displayed a hardcoded "No" — never wired to any data source. Replaced with a dynamic "Controlled Burn" cell driven by the same district XML already fetched for the Fire Danger cell (no new API call), escalating through 4 states:
  - Outside the Bush Fire Danger Period → "Notify First" (notify RFS + neighbours 24 hrs ahead, no permit)
  - Inside the BFDP → "Permit Required"
  - Inside the BFDP *and* fire danger is High+ → "Check Permit" (amber — permits can be suspended)
  - Total Fire Ban in effect → "No Burning" (full red alert, overrides everything)
- Each state links straight to the correct official RFS tool. The old static, disabled-checkbox checklist panel in the Prepare tab is removed — it's now one clear signal, visible on every tab without scrolling.
- The Bush Fire Danger Period and the daily Fire Danger Rating are separate things (confirmed against current RFS guidance) — the "Check Permit" escalation only fires when *both* conditions hold, not on a High+ rating alone.
- BFDP start/end dates come from a small hand-editable `Content/bfdpDates.json` (same pattern as the existing `AFDRSMessages.json`) rather than a hardcoded guess — there's no public feed or API for BFDP status (checked the existing Fire Danger/TOBAN feed and the RFS's full open-data catalogue on data.nsw.gov.au; neither has it), so a brigade member updates the file by hand against the [authoritative RFS table](https://www.rfs.nsw.gov.au/fire-information/BFDP) if the Commissioner varies the dates. Falls back to the statutory 1 Oct – 31 Mar default if the file is missing.

## Test plan

- [x] `npm run lint` / `npm test` / `npm run build` all pass
- [x] Verified locally (headless browser, mocked API responses) across desktop/tablet/mobile: Prepare tab layout, image cropping, numbered steps
- [x] Verified all 4 Controlled Burn states render with correct copy, colour, and links (mocked fire-danger feed + BFDP dates)
- [x] Confirmed `bfdpDates.json` is served and read correctly at the real current date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198gAEHUyLvq6Te7onr4hkS

---
_Generated by [Claude Code](https://claude.ai/code/session_0198gAEHUyLvq6Te7onr4hkS)_